### PR TITLE
#159361810 Customer cancel order

### DIFF
--- a/imports/plugins/custom/order-cancelation/client/components/CancelOrderModal.js
+++ b/imports/plugins/custom/order-cancelation/client/components/CancelOrderModal.js
@@ -2,11 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import PopModal from "react-modal";
 
-/**
- * @class
- * @constructor
- */
-class Modal extends Component {
+class CancelOrderModal extends Component {
   constructor() {
     super();
 
@@ -41,7 +37,7 @@ class Modal extends Component {
           onAfterOpen={this.afterOpenModal}
           onRequestClose={this.closeModal}
           ariaHideApp={false}
-          overlayClassName = "faq-modal"
+          overlayClassName = "cancel-order-modal"
           className="modalStyle"
           contentLabel="Example Modal"
         >
@@ -50,9 +46,9 @@ class Modal extends Component {
             <h2>Are you sure ?</h2>
             <div className="modal-ctrl-btn">
               <button className="btn btn-danger btn-cancel"
-                onClick={e => this.props.cancelOrder(e, this.props.id)}
+                onClick={this.props.cancelOrder}
               >Yes, I am</button>
-              <button className="btn btn-success btn-cancel"
+              <button className="btn btn-success btn-ignore"
                 onClick={this.props.toggleCancelModal}
               >No, I&#39;m not</button>
             </div>
@@ -63,10 +59,9 @@ class Modal extends Component {
   }
 }
 
-Modal.propTypes = {
+CancelOrderModal.propTypes = {
   cancelOrder: PropTypes.func.isRequired,
-  id: PropTypes.number.isRequired,
   toggleCancelModal: PropTypes.func.isRequired
 };
 
-export default Modal;
+export default CancelOrderModal;

--- a/imports/plugins/custom/order-cancelation/client/components/CustomOrderSummary.js
+++ b/imports/plugins/custom/order-cancelation/client/components/CustomOrderSummary.js
@@ -142,7 +142,7 @@ class CustomOrderSummary extends OrderSummary {
           order && order.workflow && order.workflow.status === "coreOrderWorkflow/canceled" &&
           this.state.rejectionReason &&
           <div className="order-summary-form-group rejection-reason-content">
-            <strong data-i18n="orderShipping.tracking">Reason For Rejection</strong>
+            <strong>Reason For Rejection</strong>
             <div className="invoice-details rejection-reason">
               {this.state.rejectionReason}
             </div>

--- a/imports/plugins/custom/order-cancelation/client/components/cancelableCompletedShopOrder.js
+++ b/imports/plugins/custom/order-cancelation/client/components/cancelableCompletedShopOrder.js
@@ -2,8 +2,8 @@ import React from "react";
 import { Meteor } from "meteor/meteor";
 import PropTypes from "prop-types";
 import { Components, replaceComponent } from "@reactioncommerce/reaction-components";
-import Modal from "./Modal";
 import RejectDeliveryModal from "./RejectDeliveryModal";
+import CancelOrderModal from "./CancelOrderModal";
 
 /**
  * @summary Displays the order breakdown for each Shop
@@ -32,31 +32,31 @@ class CancelableCompletedShopOrder extends React.Component {
 
   toggleCancelModal(event) {
     event.preventDefault();
-    this.setState({
-      showCancelModal: !this.state.showCancelModal
-    });
+    this.setState(state => ({
+      showCancelModal: !state.showCancelModal
+    }));
   }
 
   toggleRejectDeliveryModal(event) {
     event.preventDefault();
-    this.setState({
-      showRejectDeliveryModal: !this.state.showRejectDeliveryModal
-    });
+    this.setState(state => ({
+      showRejectDeliveryModal: !state.showRejectDeliveryModal
+    }));
   }
 
-  cancelOrder(event, id) {
+  cancelOrder(event) {
     event.preventDefault();
-    Meteor.call("orders/cancel", id,
+    Meteor.call("orders/cancelOrder", this.props.order, true,
       (error, response) => {
-        this.setState({
-          showCancelModal: false
-        });
         if (error) {
-          Alerts.toast("Error:", error.message);
+          Alerts.toast("Error:", error.message || "An error occurred");
         } else if (response) {
           Alerts.toast("Order Canceled");
         }
       });
+    this.setState({
+      showCancelModal: false
+    });
   }
 
   handleFormSubmit(event, id, reasonForRejection) {
@@ -107,8 +107,7 @@ class CancelableCompletedShopOrder extends React.Component {
     return (
       <div className="order-details-shop-breakdown">
         {this.state.showCancelModal &&
-          <Modal
-            id={this.order._id}
+          <CancelOrderModal
             toggleCancelModal={this.toggleCancelModal}
             cancelOrder={this.cancelOrder}
           />
@@ -124,8 +123,9 @@ class CancelableCompletedShopOrder extends React.Component {
           </div>
           {
             this.order.workflow.status === "new" &&
+            <div className="container cancel-link-container">
               <span>
-                <div className="order-details-cancel">
+                <div className="order-details-cancel pull-right">
                   <a
                     className="cancel-link"
                     href=""
@@ -135,6 +135,7 @@ class CancelableCompletedShopOrder extends React.Component {
                   </a>
                 </div>
               </span>
+            </div>
           }
           {
             // Check if order is completed and payment method is `PayOnDelivery`
@@ -157,12 +158,9 @@ class CancelableCompletedShopOrder extends React.Component {
         </div>
         <div className="order-details-info-box-topless">
           {this.items.map(function (item) {
-            return (
-              <Components.CompletedOrderItem
-                item={item} key={item._id}
-                handleDisplayMedia={handleDisplayMedia}
-              />
-            );
+            return <Components.CompletedOrderItem
+              item={item} key={item._id}
+              handleDisplayMedia={handleDisplayMedia} />;
           })}
         </div>
         {/* This is the left side / main content */}

--- a/imports/plugins/custom/order-cancelation/client/styles/main.less
+++ b/imports/plugins/custom/order-cancelation/client/styles/main.less
@@ -1,23 +1,7 @@
-@danger-color: #d41111;
 @white-color: #fff;
-@bright-purple-color: #8b6096;
-
-.order-details-cancel {
-  padding-top: 10px;
-
-  .cancel-link {
-    border: 1px solid;
-    border-radius: 3px;
-    padding: 8px;
-    &:hover{
-      background-color: @danger-color;
-      color: @white-color;
-    }
-  }
-}
 
 .modal {
-  background-color: @bright-purple-color;
+  background-color: @reaction-brand;
   color: @white-color;
 }
 
@@ -31,7 +15,7 @@
   }
 }
 
- .cancel-link-container {
+.cancel-link-container {
   padding: 10px;
 
   .order-details-cancel {
@@ -49,6 +33,36 @@
   }
 }
 
+.cancel-order-modal {
+  z-index: 3;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background-color: rgba(255, 255, 255, 0.75);
+  display: flex;
+  outline: none;
+  .modal {
+    background-color: @reaction-brand;
+    color: @white-color;
+  }
+  
+  .modal-text-content {
+    color: white;
+  }
+  
+  .modal-ctrl-btn {
+    .btn-cancel {
+      border-color: transparent !important;
+    }
+    .btn-ignore{
+      background-color: @white-color;
+      color: @reaction-brand;
+    }
+  }
+}
+
 .reject-delivery-btn {
   font-weight: normal;
   font-size: 1.3rem;
@@ -58,18 +72,6 @@
 
 .reject-delivery-btn:hover {
   text-decoration: underline
-}
-
-.reject-modal {
-  z-index: 3;
-  position: fixed;
-  top: 0px;
-  left: 0px;
-  right: 0px;
-  bottom: 0px;
-  background-color: rgba(255, 255, 255, 0.75);
-  display: flex;
-  outline: none
 }
 
 .rejection-reason-content {
@@ -92,6 +94,17 @@
     border-bottom: 2px dashed;
   }
 }
+
+.reject-modal {
+  z-index: 3;
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background-color: rgba(255, 255, 255, 0.75);
+  display: flex;
+  outline: none;
 
 .reject-delivery-modal {
   background: @reaction-brand;
@@ -192,4 +205,23 @@
 
 .roll-up-invoice-list .roll-up-content {
   margin-bottom: 4px
+}
+  
+  .modal {
+    background-color: @reaction-brand;
+    color: @white-color;
+  }
+  
+  .modal-text-content {
+    color: white;
+  }
+  .modal-ctrl-btn {
+    .btn-cancel {
+      border-color: transparent !important;
+    }
+    .btn-ignore{
+      background-color: @white-color;
+      color: @reaction-brand;
+    }
+  }
 }

--- a/imports/plugins/custom/order-cancelation/server/methods/updateOrder.js
+++ b/imports/plugins/custom/order-cancelation/server/methods/updateOrder.js
@@ -4,21 +4,6 @@ import { Meteor } from "meteor/meteor";
 import { Orders } from "/lib/collections";
 
 Meteor.methods({
-  "orders/cancel": function (orderId) {
-    check(orderId, String);
-
-    Orders.update({ _id: orderId },
-      { $set: { "workflow.status": "coreOrderWorkflow/canceled" } },
-      {}, error => {
-        if (error) {
-          Logger.error(error.message);
-          throw new Meteor.Error(error.message);
-        }
-      });
-
-    return true;
-  },
-
   "orders/cancel-payOnDelivery": function (orderId, reasonForRejection) {
     check(orderId, String);
     check(reasonForRejection, Object);

--- a/package-lock.json
+++ b/package-lock.json
@@ -535,6 +535,7 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+<<<<<<< HEAD
     },
     "axios": {
       "version": "0.18.0",
@@ -544,6 +545,8 @@
         "follow-redirects": "^1.3.0",
         "is-buffer": "^1.1.5"
       }
+=======
+>>>>>>> feat(cancel-order): implement feature to enable a customer cancel an order
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -6840,10 +6843,6 @@
         }
       }
     },
-    "jsencrypt": {
-      "version": "git+https://github.com/PaystackHQ/jsencrypt.git#023beb770624b7a39696708ba81675ac2daaaebc",
-      "from": "git+https://github.com/PaystackHQ/jsencrypt.git"
-    },
     "jsesc": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
@@ -8683,7 +8682,6 @@
         "card-validator": "^4.2.0",
         "form-urlencoded": "^2.0.9",
         "is-mobile": "^0.2.2",
-        "jsencrypt": "git+https://github.com/PaystackHQ/jsencrypt.git#023beb770624b7a39696708ba81675ac2daaaebc",
         "pusher-js": "^4.2.2"
       },
       "dependencies": {
@@ -8695,6 +8693,10 @@
             "follow-redirects": "^1.2.5",
             "is-buffer": "^1.1.5"
           }
+        },
+        "jsencrypt": {
+          "version": "git+https://github.com/PaystackHQ/jsencrypt.git#023beb770624b7a39696708ba81675ac2daaaebc",
+          "from": "git+https://github.com/PaystackHQ/jsencrypt.git#023beb770624b7a39696708ba81675ac2daaaebc"
         }
       }
     },


### PR DESCRIPTION
#### What does this PR do?
Add feature for customer to cancel an order

#### Description of Task to be completed?
- create cancel order button on order history page
- display a popup confirmation when customer tries to cancel an order
- cancel option should only be available if the orders has not been approved by the vendor
- customers money should be refunded after order has been canceled

#### How should this be manually tested?
- login as a vendor
- click on the accounts icon on the sidebar
- edit the customers group and enable order access for customer (this enables the customer cancel an order)
- login or create an account as a customer
- order for a product and checkout
- visit the order history page
- click on the cancel order button available at the top of the order details
- click yes in the modal popup to confirm deletion
- an in-app notification will be sent confirming the order has been canceled

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#159361810

#### Screenshots or gifs (if appropriate):
![cancel-order-demo](https://user-images.githubusercontent.com/13545380/44882049-a7d4ed00-aca9-11e8-92d8-3fd11ef8b452.gif)


#### Questions: